### PR TITLE
manual cleanup: Reject all endpoint connections

### DIFF
--- a/playbooks/roles/infra-aws-sandbox/tasks/clean_zone.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/clean_zone.yml
@@ -3,6 +3,7 @@
   command: >-
     aws --profile {{ account_name }}
     route53 list-resource-record-sets --hosted-zone-id {{ _hostedzoneid }}
+  changed_when: false
   register: records
 
 - set_fact:

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -1,6 +1,7 @@
 ---
 - environment:
     AWS_REGION: "{{ _region }}"
+    AWS_DEFAULT_REGION: "{{ _region }}"
     AWS_ACCESS_KEY_ID: "{{ assumed_role.sts_creds.access_key }}"
     AWS_SECRET_ACCESS_KEY: "{{ assumed_role.sts_creds.secret_key }}"
     AWS_SECURITY_TOKEN: "{{ assumed_role.sts_creds.session_token }}"
@@ -8,6 +9,25 @@
   block:
     - debug:
         var: _region
+
+    # Reject all VPC connections
+
+    - name: Get all VPC endpoint connections
+      command: >-
+         aws ec2 --region {{ _region | quote }}
+         describe-vpc-endpoint-connections
+         --query VpcEndpointConnections[] --output json
+
+      register: r_connections
+
+    - loop: "{{ r_connections.stdout | from_json }}"
+      loop_control:
+        loop_var: conn
+      command: >-
+        aws ec2 --region {{ _region | quote }}
+        reject-vpc-endpoint-connections
+        --service-id {{ conn.ServiceId }}
+        --vpc-endpoint-ids {{ conn.VpcEndpointId }}
 
     # Security groups
 
@@ -66,6 +86,7 @@
         --output json
         --query 'DBInstances[*].DBInstanceIdentifier'
       register: r_all_db_instances
+      changed_when: false
 
     - name: Save list as fact
       set_fact:

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -20,7 +20,8 @@
 
       register: r_connections
 
-    - loop: "{{ r_connections.stdout | from_json }}"
+    - name: Reject all VPC endpoint connections
+      loop: "{{ r_connections.stdout | from_json }}"
       loop_control:
         loop_var: conn
       command: >-

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -63,6 +63,9 @@
 
     - when: _awsnuke is failed
       block:
+
+        # Get a new token as the current one may have timed out (1h)
+        - include_tasks: assume.yml
         - include_tasks: global_manual_cleanup.yml
 
         - include_tasks: manual_cleanup.yml


### PR DESCRIPTION
- add manual cleanup: Reject all Endpoint Connections in all services,
  as they prevent the service to be deleted.
- add a couple of `changed_when: false` for read-only tasks
- Refresh token before running the manual tasks in case it has expired
  (default ttl is 1h, aws-nuke can sometimes takes longer)